### PR TITLE
Minor fix of broken anchor to 8th tutorial

### DIFF
--- a/gltfTutorial/README.md
+++ b/gltfTutorial/README.md
@@ -2,7 +2,7 @@
 
 This tutorial gives an introduction to [glTF](https://www.khronos.org/gltf), the GL transmission format. It summarizes the most important features and application cases of glTF, and describes the structure of the files that are related to glTF. It explains how glTF assets may be read, processed, and used to display 3D graphics efficiently.
 
-Some basic knowledge about [JSON](http://json.org/), the JavaScript Object Notation, is assumed. Additionally, a basic understanding of common graphics APIs, like OpenGL or WebGL, is required. 
+Some basic knowledge about [JSON](http://json.org/), the JavaScript Object Notation, is assumed. Additionally, a basic understanding of common graphics APIs, like OpenGL or WebGL, is required.
 
 - [Introduction](gltfTutorial_001_Introduction.md)
 - [Basic glTF Structure](gltfTutorial_002_BasicGltfStructure.md)
@@ -11,7 +11,7 @@ Some basic knowledge about [JSON](http://json.org/), the JavaScript Object Notat
 - [Buffers, BufferViews, and Accessors](gltfTutorial_005_BuffersBufferViewsAccessors.md)
 - [Example: A Simple Animation](gltfTutorial_006_SimpleAnimation.md)
 - [Animations](gltfTutorial_007_Animations.md)
-- [Example: Simple Meshes](gltfTutorial_008_Meshes.md)
+- [Example: Simple Meshes](gltfTutorial_008_SimpleMeshes.md)
 - [Meshes](gltfTutorial_009_Meshes.md)
 - [Materials](gltfTutorial_010_Materials.md)
 - [Example: A Simple Material](gltfTutorial_011_SimpleMaterial.md)
@@ -31,4 +31,3 @@ Some basic knowledge about [JSON](http://json.org/), the JavaScript Object Notat
 - Patrick Cozzi, Cesium, [@pjcozzi](https://twitter.com/pjcozzi)
 - Alexey Knyazev, [lexaknyazev](https://github.com/lexaknyazev)
 - Sarah Chow, [slchow](https://github.com/slchow)
-


### PR DESCRIPTION
Replaced broken anchor with "gltfTutorial_008_SimpleMeshes.md".